### PR TITLE
Determine fluxes associated with compartments 

### DIFF
--- a/src/CBModel.py
+++ b/src/CBModel.py
@@ -2757,6 +2757,39 @@ class Model(Fbase):
         return output
 
 
+    def getFluxesAssociatedWithCompartments(self, compartments):
+
+        """
+        Determines all reactions and flux values associated with a list of
+        compartments. This function can be used to find all transport reactions
+        between compartments, e.g. the cytosol and mitochondria. If the
+        compartment IDs are 'cyt' and 'mit', respectively, you can call
+        "your_model.getFluxesAssociatedWithCompartments(['cyt', 'mit'])"
+        to get all fluxes between these compartments.
+
+        *compartments*: a list or set of compartment IDs.
+                        To check the existing compartment IDs in your model
+                        call "your_model.getCompartmentIds()"
+
+        :returns a dictionary with reaction IDs as keys and corresponding
+        flux values as values
+        """
+
+        # check whether provided compartment ID's are valid
+        if (not set(compartments).issubset(self.getCompartmentIds()) or
+            not isinstance(compartments, (list, set))):
+            raise ValueError("Please provide valid compartment IDs as a list or"
+                             " set!")
+
+        # check whether provided compartments are identical with the ones of
+        # the reagents of a reaction; if so, add it to dictionary along with
+        # the flux value
+        return {ri: self.getReaction(ri).getValue() for ri in
+                self.getReactionIds() if set(compartments) == 
+                set(si.getCompartmentId() for si in 
+                self.getReaction(ri).getSpeciesObj())}
+
+
     def splitEqualityFluxBounds(self):
         """
         Splits any equalit flux bounds into lower and upper bounds.

--- a/src/CBModel.py
+++ b/src/CBModel.py
@@ -2781,11 +2781,13 @@ class Model(Fbase):
             raise ValueError("Please provide valid compartment IDs as a list or"
                              " set!")
 
+        compartments = set(compartments)
+
         # check whether provided compartments are identical with the ones of
         # the reagents of a reaction; if so, add it to dictionary along with
         # the flux value
         return {ri: self.getReaction(ri).getValue() for ri in
-                self.getReactionIds() if set(compartments) == 
+                self.getReactionIds() if compartments ==
                 set(si.getCompartmentId() for si in 
                 self.getReaction(ri).getSpeciesObj())}
 


### PR DESCRIPTION
Motivated by the question from [here](https://stackoverflow.com/q/50737364/1534017).

Straightforward way to determine e.g. transport reactions.

Tests could be:

```
import cbmpy as cbm

mod_name = 'e_coli_core.xml'
model = cbm.CBRead.readSBML3FBC(mod_name)

cbm.doFBA(model)

print("\n-----------\nAll reactions that have reagents from compartments c and e\n")
print(model.getFluxesAssociatedWithCompartments(['c', 'e']))

print("\n-----------\nAll reactions that have reagents from compartments c and e (also works with sets)\n")
print(model.getFluxesAssociatedWithCompartments({'c', 'e'}))

print("\n-----------\nAll reactions that have reagents only from compartment e\n")
print(model.getFluxesAssociatedWithCompartments(['e']))

try:
    print("\n-----------\nAll reactions that have reagents from compartment I_DO_NOT_EXIST (will raise an Error)\n")
    print(model.getFluxesAssociatedWithCompartments('I_DO_NOT_EXIST'))
except ValueError as e:
    print(e)
```