### PR TITLE
Updating collections import in pyparsing.py

### DIFF
--- a/cbmpy/pyparsing.py
+++ b/cbmpy/pyparsing.py
@@ -71,7 +71,10 @@ import sys
 import warnings
 import re
 import sre_constants
-import collections
+if sys.version_info.major == 3 and sys.version_info.minor >= 10 :
+    import collections.abc as collections
+else :
+    import collections
 import pprint
 #~ sys.stderr.write( "testing pyparsing module, version %s, %s\n" % (__version__,__versionTime__ ) )
 


### PR DESCRIPTION
Since python 3.10, collections no longer has a MutableMapping attribute. For backwards compatibilty it has been moved to collections.abc Importing cbmpy with python 3.10+ thus raises an AttributeError if pyparsing.py imports collections and not collections.abc.

Source of the fix : https://stackoverflow.com/questions/70943244/attributeerror-module-collections-has-no-attribute-mutablemapping